### PR TITLE
fix: platform check for windows

### DIFF
--- a/lua/roslyn/install.lua
+++ b/lua/roslyn/install.lua
@@ -52,7 +52,7 @@ local function get_rid()
 	end
 
 	-- not sure about this one
-	if platform == "windows" then
+	if platform == "windows_nt" then
 		if arch == "x86_64" then
 			return "win-x64"
 		elseif arch == "x86" then


### PR DESCRIPTION
Fixed the platform check for windows. Looks like the platform is "window_nt" not "windows"
![image](https://github.com/jmederosalvarado/roslyn.nvim/assets/8741942/808bc36b-3457-4647-9296-d496eda992b6)
 
With this change, everything seems to be working on windows! 

Thanks for all your hard work, this is great!