### PR TITLE
Add gh action to release roslyn server package

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,0 +1,96 @@
+name: Build and Release Server
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+  workflow_dispatch:
+
+jobs:
+  check-and-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ['platform1', 'platform2', 'platform3'] # Add more platforms as required
+        include:
+          - platform: 'platform1'
+            build_command: './build-command-for-platform1.sh'
+            output_directory: './path-to-platform1-output/'
+          - platform: 'platform2'
+            build_command: './build-command-for-platform2.sh'
+            output_directory: './path-to-platform2-output/'
+          # Add more platform configurations as required
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+
+      - name: Checkout source repo
+        uses: actions/checkout@v2
+        with:
+          repository: 'dotnet/roslyn'
+
+      # Check if the latest commit has changed
+      - name: Check latest commit
+        id: check-commit
+        run: |
+          LATEST_COMMIT=$(git -C roslyn log -1 --format="%H")
+          STORED_COMMIT=$(cat last_commit.txt || echo "")
+          echo "LATEST_COMMIT=${LATEST_COMMIT}" >> $GITHUB_ENV
+          if [ "$LATEST_COMMIT" = "$STORED_COMMIT" ]; then
+            echo "::set-output name=skip::true"
+          else
+            echo "${LATEST_COMMIT}" > last_commit.txt
+          fi
+
+      - name: Get .NET SDK version from global.json
+        if: steps.check-commit.outputs.skip != 'true'
+        run: |
+          DOTNET_VERSION=$(cat source/global.json | jq -r '.sdk.version')
+          echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_ENV
+
+      # If commit has changed, Build based on the platform
+      - name: Build for ${{ matrix.platform }}
+        if: steps.check-commit.outputs.skip != 'true'
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+        run: cd roslyn && ${{ matrix.build_command }}
+
+      - name: Zip for ${{ matrix.platform }}
+        if: steps.check-commit.outputs.skip != 'true'
+        run: zip -r "roslyn-server-${LATEST_COMMIT}-${{ matrix.platform }}.zip" "roslyn/artifacts"
+
+      # Commit the updated commit file
+      - name: Commit and Push
+        if: steps.check-commit.outputs.skip != 'true'
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add last_commit.txt
+          git commit -m "Update last_commit to ${LATEST_COMMIT}"
+          git push
+
+      # Create a new release and upload the build artifact
+      - name: Create Release and Upload Artifact
+        if: steps.check-commit.outputs.skip != 'true'
+        uses: gh-actions/create-release@v1
+        with:
+          tag_name: ${{ env.LATEST_COMMIT }}
+          release_name: Release ${{ env.LATEST_COMMIT }}
+          body: Automated release for commit ${{ env.LATEST_COMMIT }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Upload the artifact for current platform
+      - name: Upload Release Asset for ${{ matrix.platform }}
+        if: steps.check-commit.outputs.skip != 'true'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.LATEST_COMMIT }}_${{ matrix.platform }}.zip
+          asset_name: ${{ env.LATEST_COMMIT }}_${{ matrix.platform }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,96 +1,47 @@
-name: Build and Release Server
+name: Download and Release Roslyn
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
   workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: 'Version to download and release'
 
 jobs:
   check-and-build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: ['platform1', 'platform2', 'platform3'] # Add more platforms as required
-        include:
-          - platform: 'platform1'
-            build_command: './build-command-for-platform1.sh'
-            output_directory: './path-to-platform1-output/'
-          - platform: 'platform2'
-            build_command: './build-command-for-platform2.sh'
-            output_directory: './path-to-platform2-output/'
-          # Add more platform configurations as required
+        rid: ['osx-x64', 'osx-arm64', 'linux-x64', 'linux-arm64', 'win-x64', 'win-x86']
 
     steps:
-      - name: Checkout this repo
-        uses: actions/checkout@v2
-
-      - name: Checkout source repo
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          repository: 'dotnet/roslyn'
+          path: roslyn
+          sparse-checkout: server
 
-      # Check if the latest commit has changed
-      - name: Check latest commit
-        id: check-commit
-        run: |
-          LATEST_COMMIT=$(git -C roslyn log -1 --format="%H")
-          STORED_COMMIT=$(cat last_commit.txt || echo "")
-          echo "LATEST_COMMIT=${LATEST_COMMIT}" >> $GITHUB_ENV
-          if [ "$LATEST_COMMIT" = "$STORED_COMMIT" ]; then
-            echo "::set-output name=skip::true"
-          else
-            echo "${LATEST_COMMIT}" > last_commit.txt
-          fi
-
-      - name: Get .NET SDK version from global.json
-        if: steps.check-commit.outputs.skip != 'true'
-        run: |
-          DOTNET_VERSION=$(cat source/global.json | jq -r '.sdk.version')
-          echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_ENV
-
-      # If commit has changed, Build based on the platform
-      - name: Build for ${{ matrix.platform }}
-        if: steps.check-commit.outputs.skip != 'true'
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-        run: cd roslyn && ${{ matrix.build_command }}
+          global-json-file: roslyn/server/global.json
 
-      - name: Zip for ${{ matrix.platform }}
-        if: steps.check-commit.outputs.skip != 'true'
-        run: zip -r "roslyn-server-${LATEST_COMMIT}-${{ matrix.platform }}.zip" "roslyn/artifacts"
+      - name: Download for ${{ matrix.rid }}
+        working-directory: roslyn/server
+        run: >
+          dotnet restore
+          /p:PackageName=microsoft.codeanalysis.languageserver.${{ matrix.rid }}
+          /p:PackageVersion=${{ github.event.inputs.version }}
 
-      # Commit the updated commit file
-      - name: Commit and Push
-        if: steps.check-commit.outputs.skip != 'true'
-        run: |
-          git config user.name "GitHub Action"
-          git config user.email "action@github.com"
-          git add last_commit.txt
-          git commit -m "Update last_commit to ${LATEST_COMMIT}"
-          git push
+      - name: Package downloaded files
+        run: >
+          tar -czvf roslyn-${{ github.event.inputs.version }}-${{ matrix.rid }}.tar.gz
+          -C roslyn/server/out/microsoft.codeanalysis.languageserver.osx-arm64/${{ github.event.inputs.version }}/content/LanguageServer/${{ matrix.rid }} .
 
       # Create a new release and upload the build artifact
       - name: Create Release and Upload Artifact
-        if: steps.check-commit.outputs.skip != 'true'
-        uses: gh-actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.LATEST_COMMIT }}
-          release_name: Release ${{ env.LATEST_COMMIT }}
-          body: Automated release for commit ${{ env.LATEST_COMMIT }}
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Upload the artifact for current platform
-      - name: Upload Release Asset for ${{ matrix.platform }}
-        if: steps.check-commit.outputs.skip != 'true'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.LATEST_COMMIT }}_${{ matrix.platform }}.zip
-          asset_name: ${{ env.LATEST_COMMIT }}_${{ matrix.platform }}.zip
-          asset_content_type: application/zip
+          name: Roslyn Language Server ${{ github.event.inputs.version }}
+          tag_name: ${{ github.event.inputs.version }}
+          files: roslyn-${{ github.event.inputs.version }}-${{ matrix.rid }}.tar.gz

--- a/server/NuGet.config
+++ b/server/NuGet.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="msft_consumption" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/server/ServerDownload.csproj
+++ b/server/ServerDownload.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.Build.NoTargets/1.0.80">
+    <PropertyGroup>
+        <RestorePackagesPath>out</RestorePackagesPath>
+        <TargetFramework>net7.0</TargetFramework>
+        <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+        <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageDownload Include="$(PackageName)" version="[$(PackageVersion)]" />
+    </ItemGroup>
+</Project>

--- a/server/global.json
+++ b/server/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.404",
+    "version": "7.0.401",
     "rollForward": "latestFeature"
   }
 }

--- a/server/global.json
+++ b/server/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.404",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
The idea is to add a github action that:
- downloads the new version of the roslyn server
- packages the necessary artifacts in a zip/tar file
- uploads this package to gh releases
- does this for every supported platform

This would makes things a lot easier when trying to support things like [Mason](https://github.com/williamboman/mason.nvim). See #10.