### PR TITLE
Improved Hover Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ideally I would like to depend on the Dotnet SDK and everything else to be optio
 - Dotnet SDK (Tested with .net7).
 - [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) for some path utility functions.
 - Neovim nightly required. Tested on `831d662ac6756cab4fed6a9b394e68933b5fe325` but anything after August 2023 would probably work.
+- `markdown_inline` tree-sitter parser for good hover support.
 
 ## Setup
 

--- a/lua/roslyn/client.lua
+++ b/lua/roslyn/client.lua
@@ -86,6 +86,14 @@ function M.spawn(cmd, target, settings, on_exit, on_attach, capabilities)
 	-- 	},
 	-- })
 
+    capabilities = vim.tbl_deep_extend("force", capabilities, {
+        textDocument = {
+            hover = {
+                contentFormat = { "markdown" },
+            },
+        }
+    })
+
 	local spawned = RoslynClient.new(target)
 
 	---@diagnostic disable-next-line: missing-fields

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -334,7 +334,10 @@ end
 ---@return fun(err: lsp.ResponseError|nil, result: any)
 function Client:process_hover_response(callback)
     return function(err, result)
-        if (result.contents.kind == "markdown") then
+        if (result ~= nil
+            and result.contents.kind == "markdown"
+            and result.contents.value ~= nil
+            and result.contents.value ~= "") then
             local markdown = result.contents.value
             markdown = markdown:gsub("```csharp", "```c_sharp")
             markdown = markdown:gsub("&nbsp;", " ")


### PR DESCRIPTION
## The issue:

![before_optimized](https://github.com/jmederosalvarado/roslyn.nvim/assets/31320188/d0746840-136b-4a44-86bf-8517f90c057d)

- The default hover capability's `contentFormat` was being sent as `plaintext` by default.
- the markdown was not processed correctly, which made `&nbsp` and escape characters (`\`) be printed as strings.
- Improved the documentation to suggest the `markdown_inline` tree-sitter parser as recommended for a great hover experience

## After:

![after_optimized](https://github.com/jmederosalvarado/roslyn.nvim/assets/31320188/0c70ea25-9dae-46b6-aa38-a7c374d9b899)