### PR TITLE
Allow custom roslyn language server dll path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require("roslyn").setup({
     roslyn_version = "4.8.0-3.23475.7", -- this is the default
     on_attach = <on_attach you would pass to nvim-lspconfig>, -- required
     capabilities = <capabilities you would pass to nvim-lspconfig>, -- required
-    custom_lsp_dll_path = <path to self-compiled roslyn language server>, -- alternative to roslyn_version
+    custom_lsp_dll_path = <path to Microsoft.CodeAnalysis.LanguageServer.dll>, -- alternative to roslyn_version
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require("roslyn").setup({
     roslyn_version = "4.8.0-3.23475.7", -- this is the default
     on_attach = <on_attach you would pass to nvim-lspconfig>, -- required
     capabilities = <capabilities you would pass to nvim-lspconfig>, -- required
-    custom_lsp_dll_path = <path to Microsoft.CodeAnalysis.LanguageServer.dll>, -- alternative to roslyn_version
+    roslyn_lsp_dll_path  = <path to Microsoft.CodeAnalysis.LanguageServer.dll>, -- alternative to roslyn_version
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ require("roslyn").setup({
     roslyn_version = "4.8.0-3.23475.7", -- this is the default
     on_attach = <on_attach you would pass to nvim-lspconfig>, -- required
     capabilities = <capabilities you would pass to nvim-lspconfig>, -- required
+    custom_lsp_dll_path = <path to self-compiled roslyn language server>, -- alternative to roslyn_version
 })
 ```
 

--- a/lua/roslyn/client.lua
+++ b/lua/roslyn/client.lua
@@ -52,9 +52,9 @@ local M = {}
 ---@param target string
 ---@param on_attach function
 ---@param capabilities table
----@param custom_lsp_dll_path (string|nil)
-function M.spawn(cmd, target, settings, on_exit, on_attach, capabilities, custom_lsp_dll_path)
-    local server_path = custom_lsp_dll_path 
+---@param roslyn_lsp_dll_path (string|nil)
+function M.spawn(cmd, target, settings, on_exit, on_attach, capabilities, roslyn_lsp_dll_path)
+    local server_path = roslyn_lsp_dll_path 
     if not server_path then
         local data_path = vim.fn.stdpath("data") --[[@as string]]
         server_path = vim.fs.joinpath(data_path, "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll")

--- a/lua/roslyn/client.lua
+++ b/lua/roslyn/client.lua
@@ -52,9 +52,13 @@ local M = {}
 ---@param target string
 ---@param on_attach function
 ---@param capabilities table
-function M.spawn(cmd, target, settings, on_exit, on_attach, capabilities)
-	local data_path = vim.fn.stdpath("data") --[[@as string]]
-	local server_path = vim.fs.joinpath(data_path, "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll")
+---@param custom_lsp_dll_path (string|nil)
+function M.spawn(cmd, target, settings, on_exit, on_attach, capabilities, custom_lsp_dll_path)
+    local server_path = custom_lsp_dll_path 
+    if not server_path then
+        local data_path = vim.fn.stdpath("data") --[[@as string]]
+        server_path = vim.fs.joinpath(data_path, "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll")
+    end
 	if not vim.uv.fs_stat(server_path) then
 		vim.notify_once(
 			"Roslyn LSP server not installed. Run CSInstallRoslyn to install.",

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -54,7 +54,7 @@ M.server_config = {
 	capabilities = nil,
 	on_attach = nil,
 	settings = nil,
-	custom_lsp_dll_path = nil,
+	roslyn_lsp_dll_path = nil,
 }
 M.client_by_target = {} ---@type table<string, table|nil>
 M.targets_by_bufnr = {} ---@type table<number, string[]>
@@ -115,7 +115,7 @@ function M.attach_or_spawn(bufnr)
 	if client == nil then
 		client = require("roslyn.client").spawn(M.server_config.dotnet_cmd, target, M.server_config.settings, function()
 			M.client_by_target[target] = nil
-		end, M.server_config.on_attach, M.server_config.capabilities, M.server_config.custom_lsp_dll_path)
+		end, M.server_config.on_attach, M.server_config.capabilities, M.server_config.roslyn_lsp_dll_path)
 		if client == nil then
 			vim.notify("Failed to start Roslyn client for " .. vim.fn.fnamemodify(target, ":~:."), vim.log.levels.ERROR)
 			return

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -54,6 +54,7 @@ M.server_config = {
 	capabilities = nil,
 	on_attach = nil,
 	settings = nil,
+    custom_lsp_dll_path = nil,
 }
 M.client_by_target = {} ---@type table<string, table|nil>
 M.targets_by_bufnr = {} ---@type table<number, string[]>
@@ -114,7 +115,7 @@ function M.attach_or_spawn(bufnr)
 	if client == nil then
 		client = require("roslyn.client").spawn(M.server_config.dotnet_cmd, target, M.server_config.settings, function()
 			M.client_by_target[target] = nil
-		end, M.server_config.on_attach, M.server_config.capabilities)
+		end, M.server_config.on_attach, M.server_config.capabilities, M.server_config.custom_lsp_dll_path)
 		if client == nil then
 			vim.notify("Failed to start Roslyn client for " .. vim.fn.fnamemodify(target, ":~:."), vim.log.levels.ERROR)
 			return

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -54,7 +54,7 @@ M.server_config = {
 	capabilities = nil,
 	on_attach = nil,
 	settings = nil,
-    custom_lsp_dll_path = nil,
+	custom_lsp_dll_path = nil,
 }
 M.client_by_target = {} ---@type table<string, table|nil>
 M.targets_by_bufnr = {} ---@type table<number, string[]>


### PR DESCRIPTION
I like to use the latest development version of the roslyn lsp. Therefore, I suggest that roslyn.nvim supports self-compiled language servers. This addition assumes that the roslyn lsp pipe interface is stable which seems to be the case. 