### PR TITLE
Implement command CSFixUsings

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -152,6 +152,12 @@ function M.setup_cmds()
 	vim.api.nvim_create_user_command("CSInstallRoslyn", function()
 		require("roslyn.install").install(M.server_config.dotnet_cmd, M.server_config.roslyn_version)
 	end, { desc = "Installs the roslyn server" })
+
+	vim.api.nvim_create_user_command("CSFixUsings", function()
+		local bufnr = vim.api.nvim_get_current_buf()
+		local target = get_selected_target(bufnr)
+		require("roslyn.hacks").fix_using_directives(bufnr, M.client_by_target[target])
+	end, { desc = "Remove unnecessary using directives" })
 end
 
 function M.setup(config)


### PR DESCRIPTION
I've added a nvim user command that allows you to remove all unecesarry using directives from the current buffer.
`:CSFixUsings`

You can set it up with conform.nvim to be executed every time you format the buffer:
```
{
	"stevearc/conform.nvim",
	keys = {
		{
			"<leader>f",
			function()
				require("conform").format({ async = true, lsp_fallback = true })
				if vim.bo[0].filetype == "cs" then
					vim.cmd("CSFixUsings")
				end
			end,
			mode = "",
			desc = "[F]ormat buffer",
		},
	},
	(...)
}
```

And/or you can set it up to run automatically when you write your buffer
```
vim.api.nvim_create_autocmd("BufWritePre", {
	pattern = "*",
	callback = function(args)
		if vim.bo[0].filetype == "cs" then
			vim.cmd("CSFixUsings")
		end
		-- optional, if you use conform and want this
		require("conform").format({ bufnr = args.buf })
	end,
})
```

Waiting for your feedback.

